### PR TITLE
Fix autopublisher issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches:
       - master
-    paths:
-      - "charts/**"
-      - "templates/**"
+    paths-ignore:
+      - "**.md"
+      - "**.md.gotmpl"
+      - ".github/**"
 
 jobs:
   linting:


### PR DESCRIPTION
Due to Update docs workflow, the generation of automatic documentation triggers
two releases when readme in charts folder is created.

This commit fixes that by excluding .md files detection to trigger release workflow.